### PR TITLE
Remove the second assignment for $script_dir

### DIFF
--- a/make_chroot_initrd
+++ b/make_chroot_initrd
@@ -30,7 +30,6 @@ file "$initrd" | grep -q 'gzip compressed data' || die "expecting a gzipped init
 
 # script home dir
 [ -f "$cwd/make_chroot_initrd" ]         && script_dir="$cwd"
-[ -f "`dirname $0`/make_chroot_initrd" ] && script_dir="`dirname $0`"
 [ -f "$script_dir/initrd.patch" ] || die "initrd.patch is missing"
 
 echo "making new initrd: $out"


### PR DESCRIPTION
`dirname $0` returns `.` in my computer, which overrides the value of `$cwd` and causes failures to find initrd.patch and initrd_1604.patch.